### PR TITLE
Changing the permissions of /etc/logrotate.d/wtmp to 0644 from 0664

### DIFF
--- a/manifests/defaults/debian.pp
+++ b/manifests/defaults/debian.pp
@@ -16,7 +16,7 @@ class logrotate::defaults::debian {
   logrotate::rule {
     'wtmp':
       path        => '/var/log/wtmp',
-      create_mode => '0664';
+      create_mode => '0644';
     'btmp':
       path        => '/var/log/btmp',
       create_mode => '0600';


### PR DESCRIPTION
Signed-off by: Harshal Guptaharshal.gupta@ril.com
